### PR TITLE
Implemented Auth model, added auth repos

### DIFF
--- a/app/src/main/java/com/swa/swamobileteam/data/UserAuthenticationRepository.java
+++ b/app/src/main/java/com/swa/swamobileteam/data/UserAuthenticationRepository.java
@@ -1,0 +1,7 @@
+package com.swa.swamobileteam.data;
+
+import io.reactivex.Completable;
+
+public interface UserAuthenticationRepository {
+    Completable authenticate(String login, String password);
+}

--- a/app/src/main/java/com/swa/swamobileteam/data/UserAuthenticationRepositoryImpl.java
+++ b/app/src/main/java/com/swa/swamobileteam/data/UserAuthenticationRepositoryImpl.java
@@ -1,0 +1,10 @@
+package com.swa.swamobileteam.data;
+
+import io.reactivex.Completable;
+
+public class UserAuthenticationRepositoryImpl implements UserAuthenticationRepository {
+    @Override
+    public Completable authenticate(String login, String password) {
+        return null; // TODO for rozalia: implement with 2 test cases, one for success, one for fail
+    }
+}

--- a/app/src/main/java/com/swa/swamobileteam/ui/authorization/AuthorizationContract.java
+++ b/app/src/main/java/com/swa/swamobileteam/ui/authorization/AuthorizationContract.java
@@ -4,6 +4,8 @@ import com.swa.swamobileteam.ui.base.BaseModel;
 import com.swa.swamobileteam.ui.base.BasePresenter;
 import com.swa.swamobileteam.ui.base.BaseView;
 
+import io.reactivex.Completable;
+
 public interface AuthorizationContract {
     interface View extends BaseView {
         String getLogin();
@@ -25,7 +27,17 @@ public interface AuthorizationContract {
         void login();
     }
 
+    /**
+     * Model acts as a facade that combines different interchangeable parts to provide
+     * an interface required for Presenter.
+     */
     interface Model extends BaseModel {
-
+        /**
+         * Performs user authentication with given credentials.
+         * @param login User's login.
+         * @param password User's password.
+         * @return onSuccess if user was successfully authenticated, onFailure otherwise.
+         */
+        Completable authenticate(String login, String password);
     }
 }

--- a/app/src/main/java/com/swa/swamobileteam/ui/authorization/AuthorizationModel.java
+++ b/app/src/main/java/com/swa/swamobileteam/ui/authorization/AuthorizationModel.java
@@ -1,0 +1,19 @@
+package com.swa.swamobileteam.ui.authorization;
+
+import com.swa.swamobileteam.data.UserAuthenticationRepository;
+import com.swa.swamobileteam.data.UserAuthenticationRepositoryImpl;
+
+import io.reactivex.Completable;
+
+public class AuthorizationModel implements AuthorizationContract.Model {
+    private UserAuthenticationRepository authRepository;
+
+    public AuthorizationModel() {
+        this.authRepository = new UserAuthenticationRepositoryImpl();
+    }
+
+    @Override
+    public Completable authenticate(String login, String password) {
+        return authRepository.authenticate(login, password);
+    }
+}


### PR DESCRIPTION
Implemented the model class in Auth module as a facade for repositories, because:
* auth screen contain authentication, operator calling and password restore
* these are separate tasks and should be implemented in different classes
* Model acts as a facade providing single combined interface for presenter